### PR TITLE
When ssh session is closed via the __del__ function hard kill it instead

### DIFF
--- a/plumbum/machines/session.py
+++ b/plumbum/machines/session.py
@@ -242,8 +242,13 @@ class ShellSession:
         self.close()
 
     def __del__(self):
+        # Using hard cleanup using SIGKILL for processes that weren't closed
+        # properly to prevent gevent context switches. The function self.close
+        # does many of them.
         with contextlib.suppress(Exception):
-            self.close()
+            if self.proc and self.proc.returncode is None:
+                self.proc.kill()
+        self.proc = None
 
     def alive(self):
         """Returns ``True`` if the underlying shell process is alive, ``False`` otherwise"""


### PR DESCRIPTION
of graceful kill. This is to avoid the many gevent context switches inside the graceful kill function. Gevent may raise InvalidSwitchError when a switch occures mid garbage collection cycle which causes the main thread to block.
ORION-355083